### PR TITLE
Explicitly disable LLVM stack-checking to fix SIMD on macOS Catalina

### DIFF
--- a/argonautica-rs/build.rs
+++ b/argonautica-rs/build.rs
@@ -64,7 +64,8 @@ fn main() -> Result<(), failure::Error> {
         .warnings(false)
         .extra_warnings(false);
     if IS_SIMD {
-        builder.flag_if_supported("-march=native");
+        builder.flag_if_supported("-march=native")
+            .flag_if_supported("-fno-stack-check");
     }
     let opt_level = env::var("OPT_LEVEL")?.parse::<usize>()?;
     if opt_level < 3 {


### PR DESCRIPTION
More information:
 - https://forums.developer.apple.com/thread/121887
 - https://trac.ffmpeg.org/ticket/8073#comment:12
 - https://github.com/jedisct1/libsodium/issues/848

Note, of course, as mentioned in #20, I am completely new to all of this and have no idea what I'm doing — I only know that this fixed the problem for me; but I can't speak as to whether disabling this feature is a good idea, or if there's a better way to circumvent this … LLVM bug, I think, it looks like?

Another option is simply disabling `"simd"`, so if you're not sure about this fix, don't merge it!