### PR TITLE
tempdir has been deprecated

### DIFF
--- a/argonautica-rs/Cargo.toml
+++ b/argonautica-rs/Cargo.toml
@@ -51,7 +51,7 @@ bindgen = "0.50"
 cfg-if = "0.1"
 cc = { version = "1.0.37", features = ["parallel"] }
 failure = "0.1"
-tempdir = "0.3"
+tempfile = "3.1"
 
 [dev-dependencies]
 dotenv = "0.14"

--- a/argonautica-rs/build.rs
+++ b/argonautica-rs/build.rs
@@ -3,7 +3,7 @@ extern crate cc;
 #[macro_use]
 extern crate cfg_if;
 extern crate failure;
-extern crate tempdir;
+extern crate tempfile;
 
 use std::env;
 use std::fs;
@@ -18,7 +18,7 @@ cfg_if! {
 }
 
 fn main() -> Result<(), failure::Error> {
-    let temp = tempdir::TempDir::new("argonautica")?;
+    let temp = tempfile::tempdir()?;
     let temp_dir = temp.path();
     let temp_dir_str = temp_dir.to_str().unwrap();
 


### PR DESCRIPTION
The `tempdir` crate has been deprecated in favor of the `tempfile` crate.

Ref. https://github.com/rust-lang-deprecated/tempdir#deprecation-note