### PR TITLE
Compare hashes in constant time

### DIFF
--- a/argonautica-rs/Cargo.toml
+++ b/argonautica-rs/Cargo.toml
@@ -28,6 +28,7 @@ simd = []
 [dependencies]
 base64 = "0.10"
 bitflags = "1.1"
+constant_time_eq = "0.1.5"
 failure = "0.1"
 futures = "0.1"
 futures-cpupool = "0.1"

--- a/argonautica-rs/src/lib.rs
+++ b/argonautica-rs/src/lib.rs
@@ -282,6 +282,7 @@ extern crate base64;
 extern crate bitflags;
 #[cfg(feature = "development")]
 extern crate blake2_rfc;
+extern crate constant_time_eq;
 #[macro_use]
 extern crate failure;
 extern crate futures;

--- a/argonautica-rs/src/verifier.rs
+++ b/argonautica-rs/src/verifier.rs
@@ -143,12 +143,10 @@ impl<'a> Verifier<'a> {
                 self.hasher.config.set_version(hash_raw.version());
                 self.hasher.salt = hash_raw.raw_salt_bytes().into();
                 let hash_raw2 = self.hasher.hash_raw()?;
-                let is_valid = if hash_raw.raw_hash_bytes() == hash_raw2.raw_hash_bytes() {
-                    true
-                } else {
-                    false
-                };
-                Ok(is_valid)
+                Ok(constant_time_eq::constant_time_eq(
+                    hash_raw.raw_hash_bytes(),
+                    hash_raw2.raw_hash_bytes(),
+                ))
             }
             Hash::Raw(ref hash_raw) => {
                 self.hasher
@@ -162,12 +160,10 @@ impl<'a> Verifier<'a> {
                 self.hasher.config.set_version(hash_raw.version());
                 self.hasher.salt = hash_raw.raw_salt_bytes().into();
                 let hash_raw2 = self.hasher.hash_raw()?;
-                let is_valid = if hash_raw.raw_hash_bytes() == hash_raw2.raw_hash_bytes() {
-                    true
-                } else {
-                    false
-                };
-                Ok(is_valid)
+                Ok(constant_time_eq::constant_time_eq(
+                    hash_raw.raw_hash_bytes(),
+                    hash_raw2.raw_hash_bytes(),
+                ))
             }
             Hash::None => return Err(Error::new(ErrorKind::HashMissingError)),
         }


### PR DESCRIPTION
This should fix #19 by using the constant_time_eq crate to compare hashes.
I also tried to make `verify` more readable by moving duplicated code out of the match arms.

The changes in #31 were used to benchmark both commits. No regressions were found.